### PR TITLE
switch from localtime() to gmtime() for generating RFC-822 time formats

### DIFF
--- a/genRSS.py
+++ b/genRSS.py
@@ -430,7 +430,7 @@ def main(argv=None):
             sortedFiles = zip(fileNames, pubDates)
 
         # write dates in RFC-822 format
-        sortedFiles = ((f[0], time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.localtime(f[1]))) for f in sortedFiles)
+        sortedFiles = ((f[0], time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime(f[1]))) for f in sortedFiles)
 
         # build items
         items = [fileToItem(host, fname, pubDate) for fname, pubDate in sortedFiles]


### PR DESCRIPTION
I live in Germany where we're currently using CEST which ist GMT+2 as the default time zone. genRSS.py actually generates times in localtime (which is as stated GMT+2 für me at the moment). Unfortunately the time zone is hard-coded to be "+0000".
Therefore all my times are off by 2 hours.
It can be fixed quite easily: As the hard-coded time zone is +0000 (which is GMT/UTC) you can simply generate the times in GMT and not in the local time.