### PR TITLE
Fix: Use util.get_files to resolve undefined error

### DIFF
--- a/src/genRSS.py
+++ b/src/genRSS.py
@@ -209,7 +209,7 @@ def main(argv=None):
         # get the list of the desired files
         if opts.extensions is not None:
             opts.extensions = [e for e in opts.extensions.split(",") if e != ""]
-        file_names = get_files(
+        file_names = util.get_files(
             dirname, extensions=opts.extensions, recursive=opts.recursive, followlinks=opts.followlinks
         )
         if len(file_names) == 0:


### PR DESCRIPTION
Fixed "undefined name `get_files`" error in genRSS.py by explicitly using util.get_files for proper module reference. This ensures correct function usage and resolves runtime issues.